### PR TITLE
Fixed minor bug where hide behavior gets inverted

### DIFF
--- a/FLVER_Editor/MainForm.cs
+++ b/FLVER_Editor/MainForm.cs
@@ -1390,6 +1390,7 @@ public partial class MainWindow : Form
                 break;
             case 4:
                 Flver.Meshes.Insert(rowIndex, Flver.Meshes[rowIndex].Copy());
+                DeselectAllSelectedThings();
                 UpdateUI();
                 UpdateMesh();
                 break;


### PR DESCRIPTION
Superficial fix for the hide issue, we deselect everything after duplicating so the state of the application is as it expects it to be.