### PR TITLE
Fixing updateIndiceslist behavior and adding proper value finding for hide state. BUG FIX for hide all error due to index of the checkbox shifting up

### DIFF
--- a/FLVER_Editor/MainForm.cs
+++ b/FLVER_Editor/MainForm.cs
@@ -1,5 +1,6 @@
 ﻿using System.Diagnostics;
 using System.Numerics;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -1146,18 +1147,29 @@ public partial class MainWindow : Form
 
     private static bool AreCheckboxesInDataTableAllChecked(DataGridView table, int columnIndex)
     {
-        bool allChecked = true;
         foreach (DataGridViewRow row in table.Rows)
             if (!(bool)row.Cells[columnIndex].Value)
-                allChecked = false;
-        return allChecked;
+                return false;
+
+
+
+        return true;
     }
+
 
     private static void ToggleCheckboxesInDataTable(DataGridView table, int columnIndex)
     {
         bool allChecked = AreCheckboxesInDataTableAllChecked(table, columnIndex);
+        
+        var watch = System.Diagnostics.Stopwatch.StartNew();
+
+
+
         foreach (DataGridViewRow row in table.Rows)
             row.Cells[columnIndex].Value = !allChecked;
+
+        var time = watch.ElapsedMilliseconds;
+        System.Diagnostics.Debug.WriteLine(time);
     }
 
     private void MaterialsTableApplyToAllButtonClicked(object sender, MouseEventArgs e)
@@ -1636,7 +1648,7 @@ public partial class MainWindow : Form
             if ((bool)row.Cells[columnIndex].Value && !allChecked) continue;
             switch (columnIndex)
             {
-                case 4 when table == meshTable:
+                case 5 when table == meshTable:
                     HiddenMeshIndices = UpdateIndicesList(meshTable, HiddenMeshIndices, columnIndex, row.Index, ref MeshIsHidden);
                     break;
                 case 4 when table == dummiesTable:
@@ -1649,7 +1661,7 @@ public partial class MainWindow : Form
         }
         switch (columnIndex)
         {
-            case 4 when table == meshTable:
+            case 5 when table == meshTable:
                 UpdateMesh();
                 break;
             case 4 when table == dummiesTable:
@@ -2785,7 +2797,7 @@ public partial class MainWindow : Form
 
     private void HideAllMeshesButton_MouseClick(object sender, MouseEventArgs e)
     {
-        ModifyAllThings(meshTable, 4);
+        ModifyAllThings(meshTable, 5);
     }
 
     private void PatreonToolStripMenuItem_Click(object sender, EventArgs e)

--- a/FLVER_Editor/MainForm.cs
+++ b/FLVER_Editor/MainForm.cs
@@ -926,27 +926,16 @@ public partial class MainWindow : Form
             row.Cells.AddRange(new DataGridViewTextBoxCell { Value = i },
                 new DataGridViewTextBoxCell { Value = Flver.Materials[mesh.MaterialIndex].Name });
             row.Cells.Add(new DataGridViewButtonCell { Value = "Apply" });
-            
             try
             {
-                row.Cells.Add(new DataGridViewCheckBoxCell { Value = SelectedMeshIndices.Any(x => x == i) });
+                row.Cells.Add(new DataGridViewCheckBoxCell { Value = SelectedMeshIndices[i] >= 0 });
             }
             catch
             {
                 row.Cells.Add(new DataGridViewCheckBoxCell { Value = false });
             }
-
             row.Cells.Add(new DataGridViewButtonCell { Value = "Duplicate" });
-
-            try
-            {
-                row.Cells.Add(new DataGridViewCheckBoxCell { Value = HiddenMeshIndices.Any(x => x == i) });
-            }
-            catch
-            {
-                row.Cells.Add(new DataGridViewCheckBoxCell { Value = false });
-            }
-
+            row.Cells.Add(new DataGridViewCheckBoxCell { Value = false });
             meshTable.Rows.Add(row);
         }
         for (int i = 0; i < Flver.Dummies.Count; ++i)
@@ -1260,20 +1249,17 @@ public partial class MainWindow : Form
     private static List<int> UpdateIndicesList(DataGridView dataTable, List<int> indices, int columnIndex, int rowIndex, ref bool selectedFlag)
     {
         if (rowIndex < 0) return indices;
-
-        // after any data interaction the table enters edited mode first, with the event we are reacting to we are checking the data before it is commited as the true value so instead we get the current value in edited mode and we use it to check for our current status
-        var isChecked = (bool)dataTable[columnIndex, rowIndex].EditedFormattedValue;
-
-        if (isChecked)
+        if ((bool)dataTable[columnIndex, rowIndex].Value)
         {
             if (indices.IndexOf(rowIndex) == -1) indices.Add(rowIndex);
+            else indices.RemoveAt(indices.IndexOf(rowIndex));
         }
         else
         {
             if (indices.Count < 1) selectedFlag = true;
-            if (indices.IndexOf(rowIndex) != -1) indices.RemoveAt(indices.IndexOf(rowIndex));
+            if (indices.IndexOf(rowIndex) == -1) indices.Add(rowIndex);
+            else indices.RemoveAt(indices.IndexOf(rowIndex));
         }
-
         return indices;
     }
 

--- a/FLVER_Editor/MainForm.cs
+++ b/FLVER_Editor/MainForm.cs
@@ -921,16 +921,27 @@ public partial class MainWindow : Form
             row.Cells.AddRange(new DataGridViewTextBoxCell { Value = i },
                 new DataGridViewTextBoxCell { Value = Flver.Materials[mesh.MaterialIndex].Name });
             row.Cells.Add(new DataGridViewButtonCell { Value = "Apply" });
+            
             try
             {
-                row.Cells.Add(new DataGridViewCheckBoxCell { Value = SelectedMeshIndices[i] >= 0 });
+                row.Cells.Add(new DataGridViewCheckBoxCell { Value = SelectedMeshIndices.Any(x => x == i) });
             }
             catch
             {
                 row.Cells.Add(new DataGridViewCheckBoxCell { Value = false });
             }
+
             row.Cells.Add(new DataGridViewButtonCell { Value = "Duplicate" });
-            row.Cells.Add(new DataGridViewCheckBoxCell { Value = false });
+
+            try
+            {
+                row.Cells.Add(new DataGridViewCheckBoxCell { Value = HiddenMeshIndices.Any(x => x == i) });
+            }
+            catch
+            {
+                row.Cells.Add(new DataGridViewCheckBoxCell { Value = false });
+            }
+
             meshTable.Rows.Add(row);
         }
         for (int i = 0; i < Flver.Dummies.Count; ++i)
@@ -1244,17 +1255,20 @@ public partial class MainWindow : Form
     private static List<int> UpdateIndicesList(DataGridView dataTable, List<int> indices, int columnIndex, int rowIndex, ref bool selectedFlag)
     {
         if (rowIndex < 0) return indices;
-        if ((bool)dataTable[columnIndex, rowIndex].Value)
+
+        // after any data interaction the table enters edited mode first, with the event we are reacting to we are checking the data before it is commited as the true value so instead we get the current value in edited mode and we use it to check for our current status
+        var isChecked = (bool)dataTable[columnIndex, rowIndex].EditedFormattedValue;
+
+        if (isChecked)
         {
             if (indices.IndexOf(rowIndex) == -1) indices.Add(rowIndex);
-            else indices.RemoveAt(indices.IndexOf(rowIndex));
         }
         else
         {
             if (indices.Count < 1) selectedFlag = true;
-            if (indices.IndexOf(rowIndex) == -1) indices.Add(rowIndex);
-            else indices.RemoveAt(indices.IndexOf(rowIndex));
+            if (indices.IndexOf(rowIndex) != -1) indices.RemoveAt(indices.IndexOf(rowIndex));
         }
+
         return indices;
     }
 

--- a/FLVER_Editor/MainForm.cs
+++ b/FLVER_Editor/MainForm.cs
@@ -715,6 +715,7 @@ public partial class MainWindow : Form
             vertexPosColorList.Add(new VertexPositionColor(new XnaVector3(absolutePos.X, absolutePos.Z, absolutePos.Y),
                 Microsoft.Xna.Framework.Color.Purple));
         }
+
         for (int i = 0; i < Flver.Bones.Count; ++i)
         {
             bonesTransform[i] = new Transform3D { RotationOrder = RotationOrder, Position = new Vector3D(Flver.Bones[i].Translation) };
@@ -734,6 +735,7 @@ public partial class MainWindow : Form
             vertexPosColorList.Add(new VertexPositionColor(new XnaVector3(absolutePos.X, absolutePos.Z, absolutePos.Y),
                 Microsoft.Xna.Framework.Color.Purple));
         }
+
         for (int i = 0; i < Flver.Dummies.Count; ++i)
         {
             FLVER.Dummy dummy = Flver.Dummies[i];
@@ -757,6 +759,7 @@ public partial class MainWindow : Form
                 baseDummyYPos -= posStep;
             }
         }
+
         if (UseCheckingPoint)
         {
             Vector3 checkingPoint = CheckingPoint;
@@ -776,9 +779,11 @@ public partial class MainWindow : Form
                     checkingPoint.Y + 0.2f * checkingPointNormal.Y),
                 Microsoft.Xna.Framework.Color.Blue));
         }
+
         Viewer.vertices = vertexPosColorList.ToArray();
         Viewer.vertexTexMapList = vertexTexMapList.ToArray();
         Viewer.faceSets = faceSetPosColorList.ToArray();
+
         if (DisplayMaleBody) Flver.Meshes.Remove(MaleBodyFlver.Meshes[0]);
         else if (DisplayFemaleBody) Flver.Meshes.Remove(FemaleBodyFlver.Meshes[0]);
     }
@@ -952,7 +957,7 @@ public partial class MainWindow : Form
                 new DataGridViewTextBoxCell { Value = dummy.ReferenceID },
                 new DataGridViewTextBoxCell { Value = dummy.AttachBoneIndex },
                 new DataGridViewTextBoxCell { Value = dummy.ParentBoneIndex });
-            row.Cells.Add(new DataGridViewCheckBoxCell { Value = false });
+            row.Cells.Add(new DataGridViewCheckBoxCell { Value = SelectedDummyIndices.Any(x => x == i) });
             row.Cells.Add(new DataGridViewButtonCell { Value = dummiesTable.Columns[5].HeaderText });
             dummiesTable.Rows.Add(row);
         }

--- a/FLVER_Editor/MainForm.cs
+++ b/FLVER_Editor/MainForm.cs
@@ -1160,16 +1160,8 @@ public partial class MainWindow : Form
     private static void ToggleCheckboxesInDataTable(DataGridView table, int columnIndex)
     {
         bool allChecked = AreCheckboxesInDataTableAllChecked(table, columnIndex);
-        
-        var watch = System.Diagnostics.Stopwatch.StartNew();
-
-
-
         foreach (DataGridViewRow row in table.Rows)
             row.Cells[columnIndex].Value = !allChecked;
-
-        var time = watch.ElapsedMilliseconds;
-        System.Diagnostics.Debug.WriteLine(time);
     }
 
     private void MaterialsTableApplyToAllButtonClicked(object sender, MouseEventArgs e)

--- a/FLVER_Editor/MainForm.cs
+++ b/FLVER_Editor/MainForm.cs
@@ -716,26 +716,6 @@ public partial class MainWindow : Form
                 Microsoft.Xna.Framework.Color.Purple));
         }
 
-        for (int i = 0; i < Flver.Bones.Count; ++i)
-        {
-            bonesTransform[i] = new Transform3D { RotationOrder = RotationOrder, Position = new Vector3D(Flver.Bones[i].Translation) };
-            bonesTransform[i].SetRotationInRadians(new Vector3D(Flver.Bones[i].Rotation));
-            bonesTransform[i].Scale = new Vector3D(Flver.Bones[i].Scale);
-            if (Flver.Bones[i].ParentIndex < 0) continue;
-            bonesTransform[i].Parent = bonesTransform[Flver.Bones[i].ParentIndex];
-            Vector3D absolutePos = bonesTransform[i].GetGlobalOrigin();
-            if (bonesTransform[Flver.Bones[i].ParentIndex] == null) continue;
-            Vector3D parentPos = bonesTransform[Flver.Bones[i].ParentIndex].GetGlobalOrigin();
-            vertexPosColorList.Add(new VertexPositionColor(new XnaVector3(parentPos.X - 0.005f, parentPos.Z - 0.005f, parentPos.Y),
-                Microsoft.Xna.Framework.Color.Purple));
-            vertexPosColorList.Add(new VertexPositionColor(new XnaVector3(absolutePos.X, absolutePos.Z, absolutePos.Y),
-                Microsoft.Xna.Framework.Color.Purple));
-            vertexPosColorList.Add(new VertexPositionColor(new XnaVector3(parentPos.X + 0.005f, parentPos.Z + 0.005f, parentPos.Y),
-                Microsoft.Xna.Framework.Color.Purple));
-            vertexPosColorList.Add(new VertexPositionColor(new XnaVector3(absolutePos.X, absolutePos.Z, absolutePos.Y),
-                Microsoft.Xna.Framework.Color.Purple));
-        }
-
         for (int i = 0; i < Flver.Dummies.Count; ++i)
         {
             FLVER.Dummy dummy = Flver.Dummies[i];


### PR DESCRIPTION
- Update behavior of UpdateIndicesList to use the current value of a checkbox even in editing mode
- Fixed checking for index presence in Indices List
- Due to adding duplicate button the hide checkbox was moved by 1 index causing an error to be thrown when trying to hide all elements