### PR TITLE
Fix dummy position/rotation based on parent bones

### DIFF
--- a/FLVER_Editor/MainForm.cs
+++ b/FLVER_Editor/MainForm.cs
@@ -722,22 +722,37 @@ public partial class MainWindow : Form
             FLVER.Dummy dummy = Flver.Dummies[i];
             bool shouldSelectDummy = DummyIsSelected && SelectedDummyIndices.IndexOf(i) != -1;
             Microsoft.Xna.Framework.Color dummyColor = shouldSelectDummy ? Microsoft.Xna.Framework.Color.Yellow : Microsoft.Xna.Framework.Color.Purple;
-            float baseDummyYPos = dummy.Position.Y;
             const float posStep = 0.0005f;
+            const float dummyCrossLength = 0.025f;
+
+            var pos = new Vector3(dummy.Position.X, dummy.Position.Y, dummy.Position.Z);
+
+            Vector3 OffsetPos(Vector3 pos, FLVER2 flver, FLVER.Dummy dummy)
+            {
+                if (dummy.ParentBoneIndex >= 0)
+                    return VecUtils.RecursiveBoneOffset(pos, Flver.Bones[dummy.ParentBoneIndex], Flver);
+                return pos;
+            }
+
+            pos = OffsetPos(pos, Flver, dummy);
+            var forwardPos = OffsetPos(dummy.Position + dummy.Forward, Flver, dummy);
+            var crossPos1 = OffsetPos(dummy.Position + new Vector3(-dummyCrossLength, 0, 0), Flver, dummy);
+            var crossPos2 = OffsetPos(dummy.Position + new Vector3(dummyCrossLength, 0, 0), Flver, dummy);
+            var crossPos3 = OffsetPos(dummy.Position + new Vector3(0, -dummyCrossLength, 0), Flver, dummy);
+            var crossPos4 = OffsetPos(dummy.Position + new Vector3(0, dummyCrossLength, 0), Flver, dummy);
+
             for (int j = 0; j < DummyThickness; ++j)
             {
                 vertexPosColorList.AddRange(new[]
                 {
-                    new VertexPositionColor(new XnaVector3(dummy.Position.X - 0.025f, dummy.Position.Z, baseDummyYPos), dummyColor),
-                    new VertexPositionColor(new XnaVector3(dummy.Position.X + 0.025f, dummy.Position.Z, baseDummyYPos), dummyColor),
-                    new VertexPositionColor(new XnaVector3(dummy.Position.X, dummy.Position.Z - 0.025f, baseDummyYPos), dummyColor),
-                    new VertexPositionColor(new XnaVector3(dummy.Position.X, dummy.Position.Z + 0.025f, baseDummyYPos), dummyColor),
-                    new VertexPositionColor(new XnaVector3(dummy.Position.X, dummy.Position.Z, baseDummyYPos), Microsoft.Xna.Framework.Color.Green),
-                    new VertexPositionColor(new XnaVector3(dummy.Position.X + dummy.Forward.X, dummy.Position.Z + dummy.Forward.Z,
-                            baseDummyYPos + dummy.Forward.Y),
+                    new VertexPositionColor(new XnaVector3(crossPos1.X, crossPos1.Z, crossPos1.Y + posStep*j), dummyColor),
+                    new VertexPositionColor(new XnaVector3(crossPos2.X, crossPos2.Z, crossPos2.Y + posStep*j), dummyColor),
+                    new VertexPositionColor(new XnaVector3(crossPos3.X, crossPos3.Z, crossPos3.Y + posStep*j), dummyColor),
+                    new VertexPositionColor(new XnaVector3(crossPos4.X, crossPos4.Z, crossPos4.Y + posStep*j), dummyColor),
+                    new VertexPositionColor(new XnaVector3(pos.X, pos.Z, pos.Y + posStep*j), Microsoft.Xna.Framework.Color.Green),
+                    new VertexPositionColor(new XnaVector3(forwardPos.X, forwardPos.Z, forwardPos.Y + posStep*j),
                         Microsoft.Xna.Framework.Color.Green)
                 });
-                baseDummyYPos -= posStep;
             }
         }
 

--- a/FLVER_Editor/Mono3D.cs
+++ b/FLVER_Editor/Mono3D.cs
@@ -1048,8 +1048,15 @@ namespace FLVER_Editor
             DrawScreenText(zAxisLabel, lines[2].Position, viewMatrix, projection);
             DrawScreenText(yAxisLabel, lines[5].Position, viewMatrix, projection);
             if (!MainWindow.AreDummyIdsVisible) return;
-            foreach (FLVER.Dummy d in MainWindow.Flver.Dummies)
-                DrawScreenText(d.ReferenceID.ToString(), d.Position, viewMatrix, projection);
+            foreach (FLVER.Dummy dummy in MainWindow.Flver.Dummies)
+            {
+                var pos = new System.Numerics.Vector3(dummy.Position.X, dummy.Position.Y, dummy.Position.Z);
+
+                if (dummy.ParentBoneIndex >= 0)
+                    pos = VecUtils.RecursiveBoneOffset(pos, Flver.Bones[dummy.ParentBoneIndex], Flver);
+
+                DrawScreenText(dummy.ReferenceID.ToString(), pos, viewMatrix, projection);
+            }
         }
 
         public static Ray GetMouseRay(Vector2 mousePosition, Viewport viewport, BasicEffect camera)

--- a/FLVER_Editor/VecUtils.cs
+++ b/FLVER_Editor/VecUtils.cs
@@ -1,0 +1,46 @@
+﻿using System.Numerics;
+using SoulsFormats;
+
+namespace FLVER_Editor;
+
+public static class VecUtils
+{
+    // Rotation logic taken from cannon.js:
+    // https://github.com/schteppe/cannon.js/blob/master/src/math/Quaternion.js#L249
+    public static Vector3 RotateVector(Vector3 v, Vector3 r)
+    {
+        var quat = Quaternion.CreateFromYawPitchRoll(r.X, r.Y, r.Z);
+
+        var target = new Vector3();
+
+        var x = v.X;
+        var y = v.Y;
+        var z = v.Z;
+
+        var qx = quat.X;
+        var qy = quat.Y;
+        var qz = quat.Z;
+        var qw = quat.W;
+
+        // q*v
+        var ix = qw * x + qy * z - qz * y;
+        var iy = qw * y + qz * x - qx * z;
+        var iz = qw * z + qx * y - qy * x;
+        var iw = -qx * x - qy * y - qz * z;
+
+        target.X = ix * qw + iw * -qx + iy * -qz - iz * -qy;
+        target.Y = iy * qw + iw * -qy + iz * -qx - ix * -qz;
+        target.Z = iz * qw + iw * -qz + ix * -qy - iy * -qx;
+
+        return target;
+    }
+
+    // Offset a vector position by the rotation and translation of a bone it is attached to
+    public static Vector3 RecursiveBoneOffset(Vector3 pos, FLVER.Bone bone, FLVER2 flver)
+    {
+        pos = RotateVector(pos, bone.Rotation) + bone.Translation;
+        if (bone.ParentIndex >= 0)
+            return RecursiveBoneOffset(pos, flver.Bones[bone.ParentIndex], flver);
+        return pos;
+    }
+}


### PR DESCRIPTION
Dummypolys that had parent bones which had translations/rotations weren't being offset correctly. They are now.

This is only for display in the viewport, and I have NOT fixed any logic in regards to the X/Y/Z form inputs when scaling/translating/rotating the dummies.

Before:

![image](https://github.com/Pear0533/FLVER_Editor/assets/1077140/fcbfeb23-736a-4ddf-81af-743a2066bbbf)

After:

![image](https://github.com/Pear0533/FLVER_Editor/assets/1077140/0ac8931c-40c3-424c-bdbc-752d414f902e)


Comparison to DSAS:

![2024-02-02_00-48-08__DS_ANIM_STUDIO](https://github.com/Pear0533/FLVER_Editor/assets/1077140/a1e69156-1e86-46dd-aa48-03d27eaf091a)
