### PR TITLE
Fixing a few bugs from Action System

### DIFF
--- a/FLVER_Editor/Actions/ApplyMeshSimpleSkinAction.cs
+++ b/FLVER_Editor/Actions/ApplyMeshSimpleSkinAction.cs
@@ -27,6 +27,8 @@ public class ApplyMeshSimpleSkinAction : TransformAction
 
     public override void Execute()
     {
+        oldUnweightedVerts.Clear();
+
         foreach (FLVER.Vertex v in unweightedVerts)
         {
             v.BoneIndices[0] = boneIndex;

--- a/FLVER_Editor/Actions/CenterMeshToWorldAction.cs
+++ b/FLVER_Editor/Actions/CenterMeshToWorldAction.cs
@@ -15,7 +15,7 @@ namespace FLVER_Editor.Actions
         private readonly float[] totals;
         private readonly Action refresher;
 
-        public CenterMeshToWorldAction(IEnumerable<FLVER.Vertex> targetVertices, IEnumerable<FLVER.Dummy> targetDummies, int nbi, float[] totals, Action refresher)
+        public CenterMeshToWorldAction(List<FLVER.Vertex> targetVertices, List<FLVER.Dummy> targetDummies, int nbi, float[] totals, Action refresher)
         {
             this.targetVertices = targetVertices;
             this.targetDummies = targetDummies;

--- a/FLVER_Editor/Actions/DeleteVertexAboveAction.cs
+++ b/FLVER_Editor/Actions/DeleteVertexAboveAction.cs
@@ -32,7 +32,9 @@ public class DeleteVertexAboveAction : TransformAction
                 VertexDeleteHelper.DeleteMeshVertexFaceSet(mesh, i, facesetBackup);
 
                 oldVertexPositions.Add(i, mesh.Vertices[i].Position);
-                mesh.Vertices[i].Position = new System.Numerics.Vector3(0, 0, 0);
+                mesh.Vertices[i].Position.Z = 0;
+                mesh.Vertices[i].Position.Y = 0;
+                mesh.Vertices[i].Position.X = 0;
             }
         }
         

--- a/FLVER_Editor/Actions/DeleteVertexAction.cs
+++ b/FLVER_Editor/Actions/DeleteVertexAction.cs
@@ -6,9 +6,10 @@ namespace FLVER_Editor.Actions;
 
 public class DeleteVertexAction : TransformAction
 {
-    public DeleteVertexAction(FLVER2.Mesh mesh, Action refresher)
+    public DeleteVertexAction(FLVER2.Mesh mesh, int index, Action refresher)
     {
         this.mesh = mesh;
+        this.index = index;
         this.refresher = refresher;
     }
 
@@ -21,6 +22,8 @@ public class DeleteVertexAction : TransformAction
 
     public override void Execute()
     {
+        facesetBackup.Clear();
+        oldVertexPosition = mesh.Vertices[index].Position;
         VertexDeleteHelper.DeleteMeshVertexFaceSet(mesh, index, facesetBackup);
         mesh.Vertices[index].Position = new System.Numerics.Vector3(0, 0, 0);
         refresher.Invoke();

--- a/FLVER_Editor/Actions/DuplicateMeshAction.cs
+++ b/FLVER_Editor/Actions/DuplicateMeshAction.cs
@@ -1,0 +1,45 @@
+﻿using SoulsFormats;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FLVER_Editor.Actions;
+
+public class DuplicateMeshAction : TransformAction
+{
+    private readonly FLVER2 flver;
+    private readonly FLVER2.Mesh mesh;
+    private readonly int row;
+    private readonly Action refresher;
+
+    private FLVER2.Mesh? duplicateMesh;
+    private FLVER2.Material? duplicateMaterial;
+
+    public DuplicateMeshAction(FLVER2 flver, FLVER2.Mesh mesh, int row, Action refresher)
+    {
+        this.flver = flver;
+        this.mesh = mesh;
+        this.row = row;
+        this.refresher = refresher;
+    }
+
+    public override void Execute()
+    {
+        duplicateMesh = mesh.Copy();
+        duplicateMaterial = flver.Materials[mesh.MaterialIndex].Copy();
+        flver.Meshes.Insert(row, duplicateMesh);
+        flver.Materials.Add(duplicateMaterial);
+
+        duplicateMesh.MaterialIndex = flver.Materials.Count - 1;
+        refresher.Invoke();
+    }
+
+    public override void Undo()
+    {
+        flver.Meshes.Remove(duplicateMesh);
+        flver.Materials.Remove(duplicateMaterial);
+        refresher.Invoke();
+    }
+}

--- a/FLVER_Editor/Actions/FlipYZAction.cs
+++ b/FLVER_Editor/Actions/FlipYZAction.cs
@@ -14,7 +14,7 @@ namespace FLVER_Editor.Actions
         private readonly IEnumerable<FLVER.Dummy> targetDummies;
         private readonly Action refresher;
 
-        public FlipYZAction(IEnumerable<FLVER.Vertex> targetVertices, IEnumerable<FLVER.Dummy> targetDummies, Action refresher)
+        public FlipYZAction(IEnumerable<FLVER.Vertex> targetVertices, List<FLVER.Dummy> targetDummies, Action refresher)
         {
             this.targetVertices = targetVertices;
             this.targetDummies = targetDummies;

--- a/FLVER_Editor/Actions/Helpers/VertexDeleteHelper.cs
+++ b/FLVER_Editor/Actions/Helpers/VertexDeleteHelper.cs
@@ -28,9 +28,7 @@ public static class VertexDeleteHelper
                     backup.Add(i + 2, faceSet.Indices[i + 2]);
                     faceSet.Indices[i + 2] = index;
                 }
-
             }
-
         }
     }
 

--- a/FLVER_Editor/Actions/ImportMeshesToFlverAction.cs
+++ b/FLVER_Editor/Actions/ImportMeshesToFlverAction.cs
@@ -48,6 +48,9 @@ public class ImportMeshesToFlverAction : TransformAction
 
     public override void Execute()
     {
+        oldNodes.Clear();
+        oldBaseBones.Clear();
+        oldNodes.Clear();
         flver.Skeletons ??= new();
 
         SaveNodeFlags(flver);
@@ -77,21 +80,27 @@ public class ImportMeshesToFlverAction : TransformAction
         if (baseSkeletonLength < 0) baseSkeletonLength = 0;
         if (allSkeletonsLength < 0) allSkeletonsLength = 0;
 
-        flver.Skeletons = oldSkeleton;
 
         flver.BufferLayouts.RemoveRange(bufferLayoutCount, bufferLayoutsLength);
         flver.Materials.RemoveRange(materialsCount, materialsLength);
         flver.GXLists.RemoveRange(gxListsCount, gxListsLength);
         flver.Meshes.RemoveRange(meshesCount, meshesLength);
         flver.Nodes.RemoveRange(nodesCount, nodeLength);
-        flver.Skeletons.BaseSkeleton.RemoveRange(baseSkeletonCount, baseSkeletonLength);
-        flver.Skeletons.AllSkeletons.RemoveRange(allSkeletonsCount, allSkeletonsLength);
 
-        UndoNodesToSkeleton(flver, flver.Skeletons.BaseSkeleton, oldBaseBones);
-        UndoNodesToSkeleton(flver, flver.Skeletons.BaseSkeleton, oldAllBones);
-        
+
+        flver.Skeletons = oldSkeleton;
+
+        if (flver.Skeletons is not null)
+        {
+            flver.Skeletons.BaseSkeleton.RemoveRange(baseSkeletonCount, baseSkeletonLength);
+            flver.Skeletons.AllSkeletons.RemoveRange(allSkeletonsCount, allSkeletonsLength);
+
+            UndoNodesToSkeleton(flver, flver.Skeletons.BaseSkeleton, oldBaseBones);
+            UndoNodesToSkeleton(flver, flver.Skeletons.BaseSkeleton, oldAllBones);
+        }
+
         UndoNodeFlags(flver);
-        
+
         refresher.Invoke();
     }
 
@@ -122,7 +131,7 @@ public class ImportMeshesToFlverAction : TransformAction
 
         for (int i = 0; i < backup.Count; i++)
         {
-            var node = skeleton[i];
+            var node = backup[i];
 
             skeleton.Add(new FLVER2.SkeletonSet.Bone(node.NodeIndex)
             {

--- a/FLVER_Editor/Actions/MeshTansformAction.cs
+++ b/FLVER_Editor/Actions/MeshTansformAction.cs
@@ -24,7 +24,7 @@ public class MeshTansformAction : TransformAction
     private readonly bool uniform;
     private readonly bool vectorMode;
 
-    public MeshTansformAction(FLVER2 flver, IEnumerable<int> selectedMeshes, IEnumerable<int> selectedDummies, float offset, IReadOnlyList<float> totals, int nbi, float oldValue, float newValue, bool uniform, bool vectorMode, Action<decimal, float, bool> refresher)
+    public MeshTansformAction(FLVER2 flver, List<int> selectedMeshes, List<int> selectedDummies, float offset, IReadOnlyList<float> totals, int nbi, float oldValue, float newValue, bool uniform, bool vectorMode, Action<decimal, float, bool> refresher)
     {
         this.flver = flver;
         this.selectedMeshes = selectedMeshes;

--- a/FLVER_Editor/Actions/MirrorMeshAction.cs
+++ b/FLVER_Editor/Actions/MirrorMeshAction.cs
@@ -18,7 +18,7 @@ namespace FLVER_Editor.Actions
         private readonly Action refresher;
         private readonly float[] totals;
 
-        public MirrorMeshAction(IEnumerable<FLVER2.Mesh> targetMeshes, IEnumerable<FLVER.Dummy> targetDummies, int nbi, float[] totals, bool useWorldOrigin, bool vertexMode, Action refresher)
+        public MirrorMeshAction(List<FLVER2.Mesh> targetMeshes, List<FLVER.Dummy> targetDummies, int nbi, float[] totals, bool useWorldOrigin, bool vertexMode, Action refresher)
         {
             this.targetMeshes = targetMeshes;
             this.targetDummies = targetDummies;
@@ -58,7 +58,7 @@ namespace FLVER_Editor.Actions
                 else d.Position = MirrorThing(d.Position, nbi, totals);
             }
 
-            ReverseFaceSetsAction action = new(targetMeshes.SelectMany(x => x.FaceSets), () => { });
+            ReverseFaceSetsAction action = new(targetMeshes.SelectMany(x => x.FaceSets).ToList(), () => { });
             action.Execute();
         }
 

--- a/FLVER_Editor/Actions/ResetAllMeshesAction.cs
+++ b/FLVER_Editor/Actions/ResetAllMeshesAction.cs
@@ -14,10 +14,16 @@ namespace FLVER_Editor.Actions
         private record MeshData(BoundingRange? BoundingBox, int NodeIndex, bool UseBoneWeights, List<FLVER2.FaceSet> FaceSets, List<FLVER.Vertex> Vertices);
 
         private Dictionary<FLVER2.Mesh, MeshData> oldMeshData = new();
+        private readonly FLVER2 flver;
+
+        public ResetAllMeshesAction(FLVER2 flver)
+        {
+            this.flver = flver;
+        }
 
         public override void Execute()
         {
-            foreach (FLVER2.Mesh m in MainWindow.Flver.Meshes)
+            foreach (FLVER2.Mesh m in flver.Meshes)
             {
                 var oldVertices = new List<FLVER.Vertex>(m.Vertices);
 

--- a/FLVER_Editor/Actions/ReverseFaceSetsAction.cs
+++ b/FLVER_Editor/Actions/ReverseFaceSetsAction.cs
@@ -12,7 +12,7 @@ public class ReverseFaceSetsAction : TransformAction
     private readonly IEnumerable<FLVER2.FaceSet> facesets;
     private readonly Action refresher;
 
-    public ReverseFaceSetsAction(IEnumerable<FLVER2.FaceSet> facesets, Action refresher)
+    public ReverseFaceSetsAction(List<FLVER2.FaceSet> facesets, Action refresher)
     {
         this.facesets = facesets;
         this.refresher = refresher;

--- a/FLVER_Editor/Actions/ReverseNormalsAction.cs
+++ b/FLVER_Editor/Actions/ReverseNormalsAction.cs
@@ -8,7 +8,7 @@ public class ReverseNormalsAction : TransformAction
     private readonly IEnumerable<FLVER.Vertex> vertexes;
     private readonly Action refresher;
 
-    public ReverseNormalsAction(IEnumerable<FLVER.Vertex> vertexes, Action refresher)
+    public ReverseNormalsAction(List<FLVER.Vertex> vertexes, Action refresher)
     {
         this.vertexes = vertexes;
         this.refresher = refresher;
@@ -28,8 +28,6 @@ public class ReverseNormalsAction : TransformAction
             for (int j = 0; j < v.Tangents.Count; ++j)
                 v.Tangents[j] = new Vector4(-v.Tangents[j].X, -v.Tangents[j].Y, -v.Tangents[j].Z, v.Tangents[j].W);
         }
-
-        refresher.Invoke();
     }
 
     public override void Undo()

--- a/FLVER_Editor/Actions/SolveAllMeshLODsAction.cs
+++ b/FLVER_Editor/Actions/SolveAllMeshLODsAction.cs
@@ -12,7 +12,7 @@ namespace FLVER_Editor.Actions
         private readonly IEnumerable<FLVER2.Mesh> targetMeshes;
         private Dictionary<FLVER2.Mesh, List<FLVER2.FaceSet>> faces = new();
 
-        public SolveAllMeshLODsAction(IEnumerable<FLVER2.Mesh> targetMeshes)
+        public SolveAllMeshLODsAction(List<FLVER2.Mesh> targetMeshes)
         {
             this.targetMeshes = targetMeshes;
         }

--- a/FLVER_Editor/Mono3D.cs
+++ b/FLVER_Editor/Mono3D.cs
@@ -219,9 +219,8 @@ namespace FLVER_Editor
         {
             FLVER2.Mesh mesh = MainWindow.Flver.Meshes[targetVertexInfo.MeshIndex];
             int index = targetVertexInfo.VertexIndex;
-            DeleteVertexAction action = new DeleteVertexAction(mesh, () => MainWindow.UpdateMesh());
+            DeleteVertexAction action = new DeleteVertexAction(mesh, index, () => MainWindow.UpdateMesh());
             ActionManager.Apply(action);
-            MainWindow.UpdateMesh();
         }
 
         private void PictureBox1_MouseDown(object sender, MouseEventArgs e)
@@ -892,12 +891,12 @@ namespace FLVER_Editor
              if (state.IsKeyDown(Microsoft.Xna.Framework.Input.Keys.D5)) { Program.RotationOrder = RotationOrder.ZXY; Program.updateVertices(); }
              if (state.IsKeyDown(Microsoft.Xna.Framework.Input.Keys.D6)) { Program.RotationOrder = RotationOrder.ZYX; Program.updateVertices(); }*/
 
-            if ((state.IsKeyDown(Keys.LeftControl) || state.IsKeyDown(Keys.RightControl)) && state.IsKeyDown(Keys.Z))
+            if ((state.IsKeyDown(Keys.LeftControl) || state.IsKeyDown(Keys.RightControl)) && state.IsKeyDown(Keys.Z) && !prevState.IsKeyDown(Keys.Z))
             {
                 MainWindow.Instance?.Undo();
             }
 
-            if ((state.IsKeyDown(Keys.LeftControl) || state.IsKeyDown(Keys.RightControl)) && state.IsKeyDown(Keys.Y))
+            if ((state.IsKeyDown(Keys.LeftControl) || state.IsKeyDown(Keys.RightControl)) && state.IsKeyDown(Keys.Y) && !prevState.IsKeyDown(Keys.Y))
             {
                 MainWindow.Instance?.Redo();
             }


### PR DESCRIPTION
Fixed these issues:
- the undo action on texture changes
- the delete vertex action on the 3D view
- uncleared Cached data from action on redo
- Adding Duplicate Mesh as an action with undo
- Passing Enumerable that collected on undo which would break things as the new collected result is not the same as execute, we are not passing a list instead that is copied prior to the action with .ToList() (pretty suprising I missed this)
- ThreadSafe Invocation to be able to undo from the 3D table