### PR TITLE
Added context menu action to delete all connected vertices

### DIFF
--- a/FLVER_Editor/Actions/DeleteConnectedVerticesAction.cs
+++ b/FLVER_Editor/Actions/DeleteConnectedVerticesAction.cs
@@ -1,0 +1,89 @@
+﻿using FLVER_Editor.Actions.Helpers;
+using SoulsFormats;
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
+
+namespace FLVER_Editor.Actions
+{
+    public class DeleteConnectedVerticesAction : TransformAction
+    {
+        public DeleteConnectedVerticesAction(FLVER2.Mesh mesh, int startVertexIndex, Action refresher)
+        {
+            this.mesh = mesh;
+            this.startVertexIndex = startVertexIndex;
+            this.refresher = refresher;
+        }
+
+        private readonly FLVER2.Mesh mesh;
+        private readonly int startVertexIndex;
+        private readonly Action refresher;
+        private HashSet<int> verticesToDelete = new HashSet<int>();
+        private Dictionary<int, Vector3> oldVertexPositions = new Dictionary<int, Vector3>();
+        private Dictionary<FLVER2.FaceSet, Dictionary<int, int>> facesetBackup = new();
+
+        public override void Execute()
+        {
+            facesetBackup.Clear();
+            oldVertexPositions.Clear();
+
+            var queue = new Queue<int>();
+            queue.Enqueue(startVertexIndex);
+
+            while (queue.Count > 0)
+            {
+                int currentIndex = queue.Dequeue();
+                if (verticesToDelete.Contains(currentIndex))
+                    continue;
+
+                verticesToDelete.Add(currentIndex);
+                oldVertexPositions.Add(currentIndex, mesh.Vertices[currentIndex].Position);
+
+                foreach (var faceSet in mesh.FaceSets)
+                {
+                    var indices = faceSet.Triangulate(false);
+                    
+                    for (int i = 0; i < indices.Count; i += 3)
+                    {
+                        int v1 = indices[i];
+                        int v2 = indices[i + 1];
+                        int v3 = indices[i + 2];
+
+                        if (v1 == currentIndex || v2 == currentIndex || v3 == currentIndex)
+                        {
+                            if (v1 != currentIndex && !verticesToDelete.Contains(v1))
+                                queue.Enqueue(v1);
+                            if (v2 != currentIndex && !verticesToDelete.Contains(v2))
+                                queue.Enqueue(v2);
+                            if (v3 != currentIndex && !verticesToDelete.Contains(v3))
+                                queue.Enqueue(v3);
+                        }
+                    }
+                }
+            }
+
+            foreach (var index in verticesToDelete.OrderByDescending(i => i))
+            {
+                VertexDeleteHelper.DeleteMeshVertexFaceSet(mesh, index, facesetBackup);
+                mesh.Vertices[index].Position = new System.Numerics.Vector3(0, 0, 0);
+            }
+
+            refresher.Invoke();
+        }
+
+        public override void Undo()
+        {
+            VertexDeleteHelper.RestoreMeshVertexFaceSet(facesetBackup);
+
+            foreach (var record in oldVertexPositions)
+            {
+                var index = record.Key;
+                var position = record.Value;
+
+                mesh.Vertices[index].Position = position;
+            }
+
+            refresher.Invoke();
+        }
+    }
+}

--- a/FLVER_Editor/Mono3D.cs
+++ b/FLVER_Editor/Mono3D.cs
@@ -101,6 +101,7 @@ namespace FLVER_Editor
             cm.Items.Add("Check Vertex", null, delegate { DisplayVerticesInfo(); });
             cm.Items.Add("Edit Vertex", null, delegate { EditVerticesInfo(); });
             cm.Items.Add("Delete Selected Vertex's Faceset", null, delegate { DeleteVertex(); });
+            cm.Items.Add("Delete All connected Vertices' Facesets", null, delegate { DeleteConnectedVertices(); });
             cm.Items.Add("Delete Vertices Above", null, delegate { DeleteVertexAbove(); });
             cm.Items.Add("Delete Vertices Below", null, delegate { DeleteVertexBelow(); });
             f.ContextMenuStrip = cm;
@@ -220,6 +221,14 @@ namespace FLVER_Editor
             FLVER2.Mesh mesh = MainWindow.Flver.Meshes[targetVertexInfo.MeshIndex];
             int index = targetVertexInfo.VertexIndex;
             DeleteVertexAction action = new DeleteVertexAction(mesh, index, () => MainWindow.UpdateMesh());
+            ActionManager.Apply(action);
+        }
+
+        private void DeleteConnectedVertices()
+        {
+            FLVER2.Mesh mesh = MainWindow.Flver.Meshes[targetVertexInfo.MeshIndex];
+            int index = targetVertexInfo.VertexIndex;
+            DeleteConnectedVerticesAction action = new DeleteConnectedVerticesAction(mesh, index, () => MainWindow.UpdateMesh());
             ActionManager.Apply(action);
         }
 


### PR DESCRIPTION
I added a context menu action that deletes all vertices linked to the selected vertex by any number of connections. I found this really useful.